### PR TITLE
Add Makefile with basic tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.DEFAULT_GOAL := test
+
+clean:
+	git clean -Xdf
+	rm -rf build/ dist/
+
+test: test-playbook-syntax test-python-syntax
+
+test-playbook-syntax:
+	ansible-playbook playbooks/*.yaml --syntax-check
+
+test-python-syntax:
+	python -c 'import teamcity_build_config, teamcity_project; print(teamcity_build_config, teamcity_project)'


### PR DESCRIPTION
```
$ make test
ansible-playbook playbooks/*.yaml --syntax-check

playbook: playbooks/create_projects.yaml


playbook: playbooks/delete_projects.yaml

python -c 'import teamcity_build_config, teamcity_project; print(teamcity_build_config, teamcity_project)'
(<module 'teamcity_build_config' from 'teamcity_build_config.py'>, <module 'teamcity_project' from 'teamcity_project.py'>)
```
